### PR TITLE
Show correct navigation title for search results

### DIFF
--- a/src/constants/queries/search.graphql
+++ b/src/constants/queries/search.graphql
@@ -5,6 +5,7 @@ query search($language: Language!, $term: String!) {
 		nodes {
 			id
 			title
+			description
 			logoImage: imageWithFallback {
 				url(size: 86)
 			}
@@ -32,6 +33,7 @@ query search($language: Language!, $term: String!) {
 		nodes {
 			id
 			title
+			description
 			logoImage: imageWithFallback {
 				url(size: 86)
 			}
@@ -41,6 +43,7 @@ query search($language: Language!, $term: String!) {
 		nodes {
 			id
 			title
+			description
 			logoImage: imageWithFallback {
 				url(size: 86)
 			}

--- a/src/containers/search/Search.tsx
+++ b/src/containers/search/Search.tsx
@@ -164,8 +164,7 @@ const Search: React.FC<Props> & NavigationNavigatorProps = ({ navigation, action
 				source: { uri: item.logoImage.url },
 			}}
 			title={item.title}
-			onPress={() => {
-				console.log(item);
+			onPress={() =>
 				navigation.navigate({
 					routeName: 'Serie',
 					params: {
@@ -173,8 +172,8 @@ const Search: React.FC<Props> & NavigationNavigatorProps = ({ navigation, action
 						title: item.title,
 						description: item.description,
 					},
-				});
-			}}
+				})
+			}
 			bottomDivider
 		/>
 	);

--- a/src/containers/search/Search.tsx
+++ b/src/containers/search/Search.tsx
@@ -148,7 +148,12 @@ const Search: React.FC<Props> & NavigationNavigatorProps = ({ navigation, action
 				source: { uri: item.logoImage.url },
 			}}
 			title={item.title}
-			onPress={() => navigation.navigate({ routeName: 'Conference', params: { url: item.id, title: item.title } })}
+			onPress={() =>
+				navigation.navigate({
+					routeName: 'Conference',
+					params: { url: item.id, title: item.title, description: item.description },
+				})
+			}
 			bottomDivider
 		/>
 	);
@@ -159,7 +164,17 @@ const Search: React.FC<Props> & NavigationNavigatorProps = ({ navigation, action
 				source: { uri: item.logoImage.url },
 			}}
 			title={item.title}
-			onPress={() => navigation.navigate({ routeName: 'Serie', params: { url: item.id, title: item.title } })}
+			onPress={() => {
+				console.log(item);
+				navigation.navigate({
+					routeName: 'Serie',
+					params: {
+						url: item.id,
+						title: item.title,
+						description: item.description,
+					},
+				});
+			}}
 			bottomDivider
 		/>
 	);
@@ -170,7 +185,12 @@ const Search: React.FC<Props> & NavigationNavigatorProps = ({ navigation, action
 				source: { uri: item.logoImage.url },
 			}}
 			title={item.title}
-			onPress={() => navigation.navigate({ routeName: 'Sponsor', params: { url: item.id, title: item.title } })}
+			onPress={() =>
+				navigation.navigate({
+					routeName: 'Sponsor',
+					params: { url: item.id, title: item.title, description: item.description },
+				})
+			}
 			bottomDivider
 		/>
 	);

--- a/src/navigators/SearchNavigator.tsx
+++ b/src/navigators/SearchNavigator.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { NavigationInjectedProps } from 'react-navigation';
 import { createStackNavigator } from 'react-navigation-stack';
 
@@ -9,13 +10,35 @@ import Serie from '../containers/series/serie';
 import Sponsor from '../containers/sponsors/sponsor';
 import { GlobalStyles, headerTintColor } from '../styles';
 
+export const navigationOptionsFunction = ({ navigation }: NavigationInjectedProps) => ({
+	headerTitle: navigation.state.params ? navigation.state.params.title : '',
+	title: navigation.state.params ? navigation.state.params.title : '',
+	headerTitleContainerStyle: {
+		width: Platform.OS === 'ios' ? '60%' : '75%',
+		alignItems: Platform.OS === 'ios' ? ('center' as const) : ('flex-start' as const),
+	},
+	// WORKAROUND: https://github.com/react-navigation/react-navigation/issues/7057#issuecomment-593086348
+});
+
 const Navigator = createStackNavigator(
 	{
 		Search,
-		Presenter,
-		Conference,
-		Sponsor,
-		Serie,
+		Presenter: {
+			screen: Presenter,
+			navigationOptions: navigationOptionsFunction,
+		},
+		Conference: {
+			screen: Conference,
+			navigationOptions: navigationOptionsFunction,
+		},
+		Sponsor: {
+			screen: Sponsor,
+			navigationOptions: navigationOptionsFunction,
+		},
+		Serie: {
+			screen: Serie,
+			navigationOptions: navigationOptionsFunction,
+		},
 	},
 	{
 		navigationOptions: {


### PR DESCRIPTION
This fixes an issue where the navigation bar title was `Serie` when you tapped into a sequence from a series search. I'm also showing the sequence/conference/sponsor description on the detail page now.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/120155/96465914-c3334700-11e6-11eb-87a4-4c05c2c5b4cc.png">
