### PR TITLE
Remove cached incomplete audiobook chapters

### DIFF
--- a/src/constants/queries/audiobookRecordings.graphql
+++ b/src/constants/queries/audiobookRecordings.graphql
@@ -1,10 +1,10 @@
 #import "./fragments/recording.graphql"
-
+# We are loading <1500 recordings here since the audiobooks are cached and we want to have all of them locally
 query audiobookRecordings($language: Language!, $sequenceId: ID, $afterCursor: String) {
 	recordings(
 		language: $language
 		sequenceId: $sequenceId
-		first: 25
+		first: 1500
 		after: $afterCursor
 		orderBy: [{ field: ID, direction: ASC }]
 	) {

--- a/src/constants/queries/audiobooks.graphql
+++ b/src/constants/queries/audiobooks.graphql
@@ -1,6 +1,6 @@
-# We are loading 50 audiobooks here since the audiobooks are cached and we want to have all of them locally
+# We are loading <1000 audiobooks here since the audiobooks are cached and we want to have all of them locally
 query audiobooks($language: Language!, $afterCursor: String) {
-	audiobooks(language: $language, first: 50, after: $afterCursor, orderBy: [{ field: TITLE, direction: ASC }]) {
+	audiobooks(language: $language, first: 1000, after: $afterCursor, orderBy: [{ field: TITLE, direction: ASC }]) {
 		nodes {
 			id
 			title

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -292,6 +292,22 @@ const migrations: any = {
 			},
 		};
 	},
+	5: async (state: { [key: string]: any }) => {
+		// Clear out incorrectly cached audiobook recordings
+		const BIBLE_AND_BOOKS_DIR =
+			Platform.OS === 'ios' ? RNFetchBlob.fs.dirs.DocumentDir : `${RNFetchBlob.fs.dirs.MainBundleDir}/app_appdata`;
+		const folder = `${BIBLE_AND_BOOKS_DIR}/${Dirs.audiobooks}/`;
+		if (await RNFetchBlob.fs.isDir(folder)) {
+			const files = await RNFetchBlob.fs.ls(folder);
+			console.log('audiobook files', files);
+			for (const filename of files) {
+				if (filename.includes('audiobookRecording_')) {
+					await RNFetchBlob.fs.unlink(`${folder}/${filename}`);
+				}
+			}
+		}
+		return state;
+	},
 };
 
 // persist reducer
@@ -300,7 +316,7 @@ const persistConfig = {
 	storage: AsyncStorage,
 	whitelist: ['settings', 'playback', 'bible', 'user', 'lists', 'presenters'],
 	timeout: 0, // disable timeout https://github.com/rt2zz/redux-persist/issues/717
-	version: 4,
+	version: 5,
 	migrate: customCreateMigrate(migrations, {
 		debug: true,
 		asyncMigrations: true,


### PR DESCRIPTION
Audiobook chapters were loaded on scroll and would be cached regardless of whether all the chapters had been loaded. This clears the cached audiobook chapters and loads all audiobook chapters in the first request to avoid caching incomplete results.